### PR TITLE
productsテーブルのimage_idのカラムを削除

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -11,6 +11,7 @@ class ProductsController < ApplicationController
     end
   
     def edit
+      @products = Product.find(params[:id])
     end
   
     def update

--- a/db/migrate/20200211115137_remove_image_id_from_products.rb
+++ b/db/migrate/20200211115137_remove_image_id_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveImageIdFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :image_id, :integer, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_050134) do
+ActiveRecord::Schema.define(version: 2020_02_11_115137) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "postal_code", null: false
@@ -53,7 +53,6 @@ ActiveRecord::Schema.define(version: 2020_02_10_050134) do
     t.integer "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "image_id", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# what
productsテーブルのimage_idのカラムを削除
# why
親子関係にある子供テーブルのimagesテーブルに既に記述されているため